### PR TITLE
feat/dynamic_email_counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ out
 
 package-lock.json
 pnpm-lock.yaml
+
+# Redis
+redis.conf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+start-redis:
+	docker pull redis
+	docker run --name majaliss-landing-page-redis -d -p 6379:6379 redis
+	docker exec -it majaliss-landing-page-redis sh
+	redis-cli
+	ACL GENPASS

--- a/components/ui/Objective.vue
+++ b/components/ui/Objective.vue
@@ -1,9 +1,17 @@
+<script setup lang="ts">
+
+defineProps<{
+  objectiveValue: Ref<number>
+}>()
+
+</script>
+
 <template>
   <p
     class="home__item_left_effect mb-5 mt-1 font-syne text-[18px] text-red-brown opacity-0"
   >
     Déjà
-    <span class="mx-1 inline-block text-3xl text-gold">134</span>
+    <span class="mx-1 inline-block text-3xl text-gold">{{ objectiveValue }}</span>
     inscrits. Objectif <span class="underline">2000</span> !
   </p>
 </template>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  redis:
+    image: redis:latest
+    container_name: majaliss-landing-page-redis
+    command: redis-server /usr/local/etc/redis/redis.conf
+    restart: always
+    ports:
+      - "${REDIS_PORT}:6379"
+    volumes:
+      - ./config:/usr/local/etc/redis
+    environment:
+      - REDIS_USER=${REDIS_USER_NAME}
+      - REDIS_PASSWORD=${REDIS_USER_PASSWORD}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,5 +62,17 @@ export default defineNuxtConfig({
     preference: 'light',
   },
 
-  ssr: true,
+  // Nitro
+  nitro: {
+    storage: {
+      redis: {
+        driver: process.env.NITRO_STORAGE_DRIVER,
+        port: process.env.REDIS_PORT,
+        host: process.env.REDIS_HOST,
+        username: process.env.REDIS_USER_NAME,
+        password: process.env.REDIS_USER_PASSWORD,
+        db: 0,
+      }
+    }
+  }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -166,7 +166,7 @@ const addContactToList = () => {
 
   fetch('https://api.brevo.com/v3/contacts', options)
     .then((response) => response.json())
-    .then((response) => {
+    .then(async (response) => {
       if (response.code) {
         switch (response.code) {
           case 'duplicate_parameter':
@@ -195,6 +195,8 @@ const addContactToList = () => {
         // Set the user as subscribed
         localStorage.setItem('subscribed', 'true')
         alreadySubscribe.value = true
+        
+        await redisService.incrementEmailCounter();
 
         toast.add({
           title: 'Succès',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,16 +7,20 @@ import Objective from '~/components/ui/Objective.vue'
 
 // Imports Libraries
 import { SwiperSlide, Swiper } from 'swiper/vue'
+
 import gsap from 'gsap'
 import {
   Autoplay,
   Keyboard,
   Mousewheel,
-  Pagination,
-  Navigation,
 } from 'swiper/modules'
 
 const modules = [Autoplay, Keyboard, Mousewheel]
+
+// Services
+import { RedisService } from '~/server/services/redis.service'
+
+const redisService: RedisService = new RedisService()
 
 // Data
 const config = useRuntimeConfig()
@@ -124,6 +128,10 @@ onMounted(() => {
         '<+=0.5'
       )
   })
+})
+
+onNuxtReady(() => {
+  redisService.poller()
 })
 
 // Methods
@@ -364,7 +372,7 @@ const addContactToList = () => {
                 class="home__stars absolute -left-8 top-0 scale-0"
               />
             </p>
-            <Objective />
+            <Objective :objective-value="redisService.emailCounter" />
           </div>
           <div
             class="home__item_left_effect relative mb-2 flex h-14 flex-col rounded-xl border-[1px] border-slate-200 bg-white px-3 py-3 font-syne opacity-0 sm:mb-0 sm:h-16 sm:flex-row sm:rounded-xl sm:px-6"
@@ -423,7 +431,7 @@ const addContactToList = () => {
               >, vous pouvez rejoindre le discord dès maintenant pour être
               informé des dernières nouveautés !
             </p>
-            <Objective />
+            <Objective :objective-value="redisService.emailCounter" />
             <a
               class="mt-5 flex w-full cursor-pointer flex-row items-center justify-center gap-2 rounded-md bg-discord py-3 text-center font-medium text-white transition-colors hover:bg-dark-discord lg:w-2/4"
               href="https://discord.gg/MfqAvuca5W"
@@ -454,34 +462,34 @@ const addContactToList = () => {
           <a
             href="/"
             target="_blank"
-            class="home__socials bg-custom-blue-50 group flex h-12 w-12 items-center justify-center rounded-full opacity-0 transition-colors hover:bg-custom-blue-100"
+            class="home__socials group flex h-12 w-12 items-center justify-center rounded-full bg-custom-blue-50 opacity-0 transition-colors hover:bg-custom-blue-100"
           >
             <Icon
               name="mdi:twitter"
               size="18"
-              class="group-hover:text-custom-blue-50 text-custom-blue-100 transition-colors"
+              class="text-custom-blue-100 transition-colors group-hover:text-custom-blue-50"
             />
           </a>
           <a
             href="/"
             target="_blank"
-            class="home__socials bg-custom-blue-50 group flex h-12 w-12 items-center justify-center rounded-full opacity-0 transition-colors hover:bg-custom-blue-100"
+            class="home__socials group flex h-12 w-12 items-center justify-center rounded-full bg-custom-blue-50 opacity-0 transition-colors hover:bg-custom-blue-100"
           >
             <Icon
               name="ri:instagram-fill"
               size="18"
-              class="group-hover:text-custom-blue-50 text-custom-blue-100 transition-colors"
+              class="text-custom-blue-100 transition-colors group-hover:text-custom-blue-50"
             />
           </a>
           <a
             href="/"
             target="_blank"
-            class="home__socials bg-custom-blue-50 group flex h-12 w-12 items-center justify-center rounded-full opacity-0 transition-colors hover:bg-custom-blue-100"
+            class="home__socials group flex h-12 w-12 items-center justify-center rounded-full bg-custom-blue-50 opacity-0 transition-colors hover:bg-custom-blue-100"
           >
             <Icon
               name="fa-brands:tiktok"
               size="18"
-              class="group-hover:text-custom-blue-50 text-custom-blue-100 transition-colors"
+              class="text-custom-blue-100 transition-colors group-hover:text-custom-blue-50"
             />
           </a>
         </div>

--- a/redis.acl.conf
+++ b/redis.acl.conf
@@ -1,0 +1,11 @@
+# Generate a password
+ACL GENPASS
+
+# Create a user with password
+ACL SETUSER majaliss on -SADD ><password_generated_by_gen_pass>
+
+# Allow get & set permission
+ACL SETUSER majaliss +get +set
+
+# Allow user to access specific key
+ACL SETUSER majaliss ~majaliss:email:counter

--- a/redis.setup.conf
+++ b/redis.setup.conf
@@ -1,0 +1,8 @@
+# Before all make sure connection works
+PING
+
+# To set a key into redis
+SET <your_key> <your_value> (eg: majaliss:key '{"emailCounter":134}')
+
+# To get a key from redis
+GET <your_key>

--- a/server/api/greetings/hello.get.ts
+++ b/server/api/greetings/hello.get.ts
@@ -1,0 +1,9 @@
+import type { EventHandlerRequest, H3Event} from 'h3'
+
+export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
+    return {
+        message: "Hello from Nuxt server 👋"
+    }
+});
+
+

--- a/server/api/storage/email.get.ts
+++ b/server/api/storage/email.get.ts
@@ -1,0 +1,12 @@
+import type { EventHandlerRequest, H3Event} from 'h3'
+import { emailCounterKey } from '~/server/redis/keys';
+import type { TRedisEmailCounterData } from '~/server/types/TRedisEmailCounterData';
+
+export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
+    const data = await useStorage(process.env.NITRO_STORAGE_DRIVER)
+     .getItem<TRedisEmailCounterData>(emailCounterKey);
+
+    return {
+        emailCounter: data?.emailCounter
+    };
+});

--- a/server/api/storage/email.post.ts
+++ b/server/api/storage/email.post.ts
@@ -1,0 +1,14 @@
+import type { EventHandlerRequest, H3Event} from 'h3'
+import { emailCounterKey } from '~/server/redis/keys';
+import type { TRedisEmailCounterData } from '~/server/types/TRedisEmailCounterData';
+
+
+export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
+    const body = await readBody<TRedisEmailCounterData>(event);
+    await useStorage(process.env.NITRO_STORAGE_DRIVER)
+     .setItem<TRedisEmailCounterData>(emailCounterKey, {
+        emailCounter: body.emailCounter
+    });
+
+    return body;
+});

--- a/server/redis/keys.ts
+++ b/server/redis/keys.ts
@@ -1,0 +1,1 @@
+export const emailCounterKey = "majaliss:email:counter";

--- a/server/services/redis.service.ts
+++ b/server/services/redis.service.ts
@@ -7,7 +7,7 @@ export class RedisService {
     private _pollerTimeout: NodeJS.Timeout = setTimeout((() => {}), 5000);
     private _isRefreshPollerTime: boolean = false;
 
-    public emailCounter: Ref<number> = ref(134);
+    public emailCounter: Ref<number> = ref(0);
 
     /**
      * Singleton implementation

--- a/server/services/redis.service.ts
+++ b/server/services/redis.service.ts
@@ -1,0 +1,128 @@
+import { type Ref, ref } from "vue";
+import type { TRedisEmailCounterData } from "../types/TRedisEmailCounterData";
+
+export class RedisService {
+    private _redisServiceInstance: RedisService = this;
+    private _pollerIntervalLimit: number = new Date().getTime() + (30 * 60 * 1000);
+    private _pollerTimeout: NodeJS.Timeout = setTimeout((() => {}), 5000);
+    private _isRefreshPollerTime: boolean = false;
+
+    public emailCounter: Ref<number> = ref(134);
+
+    /**
+     * Singleton implementation
+     * @returns RedisService instance
+     */
+    constructor() {
+        if (!this._redisServiceInstance) {
+            this._redisServiceInstance = new RedisService();
+        }
+
+        return this._redisServiceInstance;
+    }
+
+    /**
+     * This method allow you to get current email counter from redis cache.
+     * @returns Promise<TRedisEmailCounterData>
+     */
+    public async getEmailCounter(): Promise<TRedisEmailCounterData>  {
+        const data = await $fetch("/api/storage/email", {
+            method: "get"
+        });
+
+        if (!data || !data.emailCounter) {
+            throw new Error(
+                `[ Error ] getEmailCounter(): 
+                 an error occured when trying to get email counter from redis.
+                 Maybe data is null : ${JSON.stringify(data)}`
+            );
+        }
+
+        return {
+            emailCounter: data.emailCounter
+        };
+    }
+
+    /**
+     * This method allow you to increment email into redis cache.
+     */
+    public async incrementEmailCounter(): Promise<void> {
+        const currentRedisData = await this.getEmailCounter();
+
+        if (!currentRedisData || !currentRedisData.emailCounter) {
+            throw new Error(
+                `[Error] getEmailCounter(): currentRedisData is maybe null : ${currentRedisData}`
+            )
+        }
+
+        const data = await $fetch("/api/storage/email", {
+            method: "post",
+            body: {
+                emailCounter: currentRedisData.emailCounter + 1
+            }
+        });
+
+        /**
+         * Ensure throw an error when result is undefined.
+         */
+        if (!data) {
+            throw new Error(
+                `[Error] fetch<POST>("/api/storage/email"): an error occured when trying to call this endpoint. Data : ${data}`
+            )
+        }
+
+        this.emailCounter.value = data.emailCounter || this.emailCounter.value;
+    }
+
+    /**
+     * This method give you it's time to refresh poller or not.
+     * @param now current time
+     * @param end limit of poller
+     * @returns boolean with wich you can make decision to refresh poller.
+     */
+    private _refreshPoller(now: number, end: number): boolean {
+        return now > end;
+    }
+
+    /**
+     * 
+     * @param duration waiting time before another request
+     * @returns Promise<unknown>
+     */
+    private _sleep(duration: number): Promise<unknown> {
+        return new Promise(resolve => {
+            this._pollerTimeout = setTimeout(resolve, duration);
+        });
+    }
+
+    /**
+     * This method poll redis cache to get emailCounter information.
+     * @param pollTimeout waiting time before another request
+     */
+    public poller(pollTimeout: number = 5000): void {
+        this.getEmailCounter()
+            .then((result) => {
+                const now = new Date().getTime();
+                this._isRefreshPollerTime = this._refreshPoller(now, this._pollerIntervalLimit);
+                this.emailCounter.value = result.emailCounter || this.emailCounter.value;
+                
+                this._sleep(pollTimeout)
+                 .then(() => {
+                    /**
+                     * To free up browser cache space
+                     */
+                    if (this._isRefreshPollerTime) {
+                       clearTimeout(this._pollerTimeout);
+                       window.location.reload();
+                    }
+
+                    this.poller(pollTimeout);
+                 });
+            })
+            .catch((err) => {
+                throw new Error(
+                    `[Error] poller(): an error occured on polling system : ${err}`
+                )
+            });
+    }
+}

--- a/server/types/TRedisEmailCounterData.ts
+++ b/server/types/TRedisEmailCounterData.ts
@@ -1,0 +1,3 @@
+export type TRedisEmailCounterData = {
+    emailCounter: number | undefined;
+};


### PR DESCRIPTION
This PR contains implementation of email counter 🚀 :

-  Every `5s`, the server request will send to redis cache and trying to get email counter.
-  An ACL user was created.

To test this PR, you should (`locally | remotely`) :
- [ ]  have a `.env` file with specific redis configuration.
- [ ] `pull` a `redis` docker image to a server that you want.
- [ ] adapt `.env` with correct configuration that refer to new server.
- [ ] create ACL user to redis (refer to `acl.conf` file).
- [ ] set manually a key into redis (refer to `redis.setup.conf`).

I recommend you to first test this PR locally before merge into main branch.

If you want, i created for you a Makefile, that can run automatically part of configuration commands you can launch it with :

`make start-redis`

After that you can continue the last ACL configuration at this step :

`# Create a user with password`
